### PR TITLE
 Added initial set of API requests and database functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Project specific
-application.yml
 target/**
 
 # IDE files

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Project specific
 application.yml
-target/*
+target/**
 
 # IDE files
 .idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Project specific
-application-local.yml
+application.yml
 target/*
 
 # IDE files

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
+# Project specific
+application-local.yml
+target/*
+
+# IDE files
+.idea/*
+.vscode/*
+
+# OS Files
+.DS_Store
+
 # Compiled class file
 *.class
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.4.1</version>
+		<relativePath /> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.stucko09</groupId>
+	<artifactId>steam-playtime-aggregator</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>steam-playtime-aggregator</name>
+	<description>An application to aggregate</description>
+	<url />
+	<licenses>
+		<license />
+	</licenses>
+	<developers>
+		<developer>
+			<name>Ryan Stuckey</name> 
+			<email>ryanstuckey0@gmail.com</email>
+		</developer>
+	</developers>
+	<scm>
+		<connection />
+		<developerConnection />
+		<tag />
+		<url />
+	</scm>
+	<properties>
+		<java.version>23</java.version>
+	</properties>
+	<dependencies>
+
+		<dependency>
+			<groupId>com.github.dozermapper</groupId>
+			<artifactId>dozer-core</artifactId>
+			<version>7.0.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<version>2.3.232</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+						<path>
+							<groupId>org.springframework.boot</groupId>
+							<artifactId>spring-boot-configuration-processor</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/main/java/com/stucko09/steam_aggregator/config/BasicAppConfig.java
+++ b/src/main/java/com/stucko09/steam_aggregator/config/BasicAppConfig.java
@@ -4,10 +4,18 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+import com.github.dozermapper.core.DozerBeanMapperBuilder;
+import com.github.dozermapper.core.Mapper;
+
 @Configuration
 public class BasicAppConfig {
     @Bean
     RestTemplate restTemplate() {
         return new RestTemplate();
+    }
+
+    @Bean
+    Mapper dozerBeanMapper() {
+        return DozerBeanMapperBuilder.buildDefault();
     }
 }

--- a/src/main/java/com/stucko09/steam_aggregator/config/BasicAppConfig.java
+++ b/src/main/java/com/stucko09/steam_aggregator/config/BasicAppConfig.java
@@ -1,0 +1,13 @@
+package com.stucko09.steam_aggregator.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class BasicAppConfig {
+    @Bean
+    RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/stucko09/steam_aggregator/config/SteamProperties.java
+++ b/src/main/java/com/stucko09/steam_aggregator/config/SteamProperties.java
@@ -10,5 +10,4 @@ import lombok.Data;
 @ConfigurationProperties(prefix = "steam")
 public class SteamProperties {
     private String hostname;
-    private String apiKey;
 }

--- a/src/main/java/com/stucko09/steam_aggregator/config/SteamProperties.java
+++ b/src/main/java/com/stucko09/steam_aggregator/config/SteamProperties.java
@@ -1,0 +1,14 @@
+package com.stucko09.steam_aggregator.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Data;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "steam")
+public class SteamProperties {
+    private String hostname;
+    private String apiKey;
+}

--- a/src/main/java/com/stucko09/steam_aggregator/controller/SimpleApiController.java
+++ b/src/main/java/com/stucko09/steam_aggregator/controller/SimpleApiController.java
@@ -3,6 +3,7 @@ package com.stucko09.steam_aggregator.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.stucko09.steam_aggregator.model.AppUser;
@@ -11,6 +12,7 @@ import com.stucko09.steam_aggregator.model.steam.SteamResponse;
 import com.stucko09.steam_aggregator.service.StatsCollectionService;
 import com.stucko09.steam_aggregator.service.SteamApiService;
 import com.stucko09.steam_aggregator.service.UserService;
+
 
 @RestController
 public class SimpleApiController {
@@ -24,18 +26,27 @@ public class SimpleApiController {
     private UserService userService;
 
     @GetMapping("/getOwnedGames/{steamId}")
-    public SteamResponse<SteamGetOwnedGamesResponse> getOwnedGames(@PathVariable Long steamId) {
-        return steamApiService.getOwnedGames(steamId);
+    public SteamResponse<SteamGetOwnedGamesResponse> getOwnedGames(@RequestHeader String apiKey, @PathVariable Long steamId) {
+        return steamApiService.getOwnedGames(steamId, apiKey);
+    }
+
+    @GetMapping("/saveInitialPlaytime/{steamId}")
+    public void saveInitialPlaytime(@RequestHeader String apiKey, @PathVariable Long steamId) {
+        AppUser user = userService.retrieveUserOrThrowException(steamId);
+        user.setApiKey(apiKey);
+        statsCollectionService.collectAndSaveInitialPlaytimeStats(user);
     }
 
     @GetMapping("/saveDailyPlaytime/{steamId}")
-    public void saveDailyPlaytime(@PathVariable Long steamId) {
+    public void saveDailyPlaytime(@RequestHeader String apiKey, @PathVariable Long steamId) {
         AppUser user = userService.retrieveUserOrThrowException(steamId);
-        statsCollectionService.collectAndSaveDailyPlaytimeStats(steamId, user);
+        user.setApiKey(apiKey);
+        statsCollectionService.collectAndSaveDailyPlaytimeStats(user);
     }
+    
 
     @GetMapping("/registerUser/{steamId}")
-    public AppUser registerUser(@PathVariable Long steamId) {
-        return userService.registerUser(steamId);
+    public void registerUser(@RequestHeader String apiKey, @PathVariable Long steamId) {
+        userService.registerUserAndSaveInitialPlaytime(steamId, apiKey);
     }
 }

--- a/src/main/java/com/stucko09/steam_aggregator/controller/SimpleApiController.java
+++ b/src/main/java/com/stucko09/steam_aggregator/controller/SimpleApiController.java
@@ -1,0 +1,21 @@
+package com.stucko09.steam_aggregator.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.stucko09.steam_aggregator.model.steam.SteamGetOwnedGamesResponse;
+import com.stucko09.steam_aggregator.model.steam.SteamResponse;
+import com.stucko09.steam_aggregator.service.SteamApiService;
+
+@RestController
+public class SimpleApiController {
+    @Autowired
+    private SteamApiService steamApiService;
+
+    @GetMapping("/getOwnedGames/{steamId}")
+    public SteamResponse<SteamGetOwnedGamesResponse> getMethodName(@PathVariable String steamId) {
+        return steamApiService.getOwnedGames(steamId);
+    }
+}

--- a/src/main/java/com/stucko09/steam_aggregator/controller/SimpleApiController.java
+++ b/src/main/java/com/stucko09/steam_aggregator/controller/SimpleApiController.java
@@ -5,10 +5,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.stucko09.steam_aggregator.model.AppUser;
 import com.stucko09.steam_aggregator.model.steam.SteamGetOwnedGamesResponse;
 import com.stucko09.steam_aggregator.model.steam.SteamResponse;
 import com.stucko09.steam_aggregator.service.StatsCollectionService;
 import com.stucko09.steam_aggregator.service.SteamApiService;
+import com.stucko09.steam_aggregator.service.UserService;
 
 @RestController
 public class SimpleApiController {
@@ -18,13 +20,22 @@ public class SimpleApiController {
     @Autowired
     private StatsCollectionService statsCollectionService;
 
+    @Autowired
+    private UserService userService;
+
     @GetMapping("/getOwnedGames/{steamId}")
     public SteamResponse<SteamGetOwnedGamesResponse> getOwnedGames(@PathVariable Long steamId) {
         return steamApiService.getOwnedGames(steamId);
     }
 
     @GetMapping("/saveDailyPlaytime/{steamId}")
-    public void updateOwnedGames(@PathVariable Long steamId) {
-        statsCollectionService.collectAndSaveDailyPlaytimeStats(steamId);
+    public void saveDailyPlaytime(@PathVariable Long steamId) {
+        AppUser user = userService.retrieveUserOrThrowException(steamId);
+        statsCollectionService.collectAndSaveDailyPlaytimeStats(steamId, user);
+    }
+
+    @GetMapping("/registerUser/{steamId}")
+    public AppUser registerUser(@PathVariable Long steamId) {
+        return userService.registerUser(steamId);
     }
 }

--- a/src/main/java/com/stucko09/steam_aggregator/controller/SimpleApiController.java
+++ b/src/main/java/com/stucko09/steam_aggregator/controller/SimpleApiController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.stucko09.steam_aggregator.model.steam.SteamGetOwnedGamesResponse;
 import com.stucko09.steam_aggregator.model.steam.SteamResponse;
+import com.stucko09.steam_aggregator.service.StatsCollectionService;
 import com.stucko09.steam_aggregator.service.SteamApiService;
 
 @RestController
@@ -14,8 +15,16 @@ public class SimpleApiController {
     @Autowired
     private SteamApiService steamApiService;
 
+    @Autowired
+    private StatsCollectionService statsCollectionService;
+
     @GetMapping("/getOwnedGames/{steamId}")
-    public SteamResponse<SteamGetOwnedGamesResponse> getMethodName(@PathVariable String steamId) {
+    public SteamResponse<SteamGetOwnedGamesResponse> getOwnedGames(@PathVariable Long steamId) {
         return steamApiService.getOwnedGames(steamId);
+    }
+
+    @GetMapping("/saveDailyPlaytime/{steamId}")
+    public void updateOwnedGames(@PathVariable Long steamId) {
+        statsCollectionService.collectAndSaveDailyPlaytimeStats(steamId);
     }
 }

--- a/src/main/java/com/stucko09/steam_aggregator/model/AppUser.java
+++ b/src/main/java/com/stucko09/steam_aggregator/model/AppUser.java
@@ -5,18 +5,20 @@ import java.time.ZonedDateTime;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Data
-public class GamePlaytimeRecord {
+@NoArgsConstructor
+public class AppUser {
     @Setter(AccessLevel.NONE)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,16 +32,10 @@ public class GamePlaytimeRecord {
     @UpdateTimestamp
     private ZonedDateTime updateTimestamp;
 
-    @ManyToOne
-    private GameRecord gameRecord;
+    @Column(unique = true)
+    private Long steamUserId;
 
-    @ManyToOne
-    private AppUser appUser;
-
-    private int playtimeForever;
-    private int playtime2Weeks;
-    private int playtimeLinuxForever;
-    private int playtimeMacForever;
-    private int playtimeWindowsForever;
-    private int playtimeDeckForever;
+    public AppUser(Long steamUserId) {
+        this.steamUserId = steamUserId;
+    }
 }

--- a/src/main/java/com/stucko09/steam_aggregator/model/AppUser.java
+++ b/src/main/java/com/stucko09/steam_aggregator/model/AppUser.java
@@ -1,16 +1,8 @@
 package com.stucko09.steam_aggregator.model;
 
-import java.time.ZonedDateTime;
-
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import lombok.AccessLevel;
+import jakarta.persistence.Transient;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -20,21 +12,11 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class AppUser extends BaseRecordClass {
-    @Setter(AccessLevel.NONE)
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Setter(AccessLevel.NONE)
-    @CreationTimestamp
-    private ZonedDateTime creationTimestamp;
-
-    @Setter(AccessLevel.NONE)
-    @UpdateTimestamp
-    private ZonedDateTime updateTimestamp;
-
     @Column(unique = true, nullable = false)
     private Long steamUserId;
+
+    @Transient
+    private String apiKey;
 
     public AppUser(Long steamUserId) {
         this.steamUserId = steamUserId;

--- a/src/main/java/com/stucko09/steam_aggregator/model/BaseRecordClass.java
+++ b/src/main/java/com/stucko09/steam_aggregator/model/BaseRecordClass.java
@@ -5,21 +5,15 @@ import java.time.ZonedDateTime;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
 import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Entity
-@Getter
-@Setter
-@NoArgsConstructor
-public class AppUser extends BaseRecordClass {
+@MappedSuperclass
+public abstract class BaseRecordClass {
     @Setter(AccessLevel.NONE)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,11 +26,4 @@ public class AppUser extends BaseRecordClass {
     @Setter(AccessLevel.NONE)
     @UpdateTimestamp
     private ZonedDateTime updateTimestamp;
-
-    @Column(unique = true, nullable = false)
-    private Long steamUserId;
-
-    public AppUser(Long steamUserId) {
-        this.steamUserId = steamUserId;
-    }
 }

--- a/src/main/java/com/stucko09/steam_aggregator/model/GamePlaytimeRecord.java
+++ b/src/main/java/com/stucko09/steam_aggregator/model/GamePlaytimeRecord.java
@@ -1,0 +1,24 @@
+package com.stucko09.steam_aggregator.model;
+
+import java.time.ZonedDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class GamePlaytimeRecord {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreationTimestamp
+    private ZonedDateTime creationTimestamp;
+
+    @UpdateTimestamp
+    private ZonedDateTime updateTimestamp;
+}

--- a/src/main/java/com/stucko09/steam_aggregator/model/GamePlaytimeRecord.java
+++ b/src/main/java/com/stucko09/steam_aggregator/model/GamePlaytimeRecord.java
@@ -1,39 +1,25 @@
 package com.stucko09.steam_aggregator.model;
 
-import java.time.ZonedDateTime;
-
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
+import com.stucko09.steam_aggregator.util.Constants;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.ManyToOne;
-import lombok.AccessLevel;
-import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Data
-public class GamePlaytimeRecord {
-    @Setter(AccessLevel.NONE)
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+@Getter
+@Setter
+@NoArgsConstructor
+public class GamePlaytimeRecord extends BaseRecordClass {
 
-    @Setter(AccessLevel.NONE)
-    @CreationTimestamp
-    private ZonedDateTime creationTimestamp;
-
-    @Setter(AccessLevel.NONE)
-    @UpdateTimestamp
-    private ZonedDateTime updateTimestamp;
-
-    @ManyToOne
+    @ManyToOne(optional = false)
     private GameRecord gameRecord;
 
-    @ManyToOne
+    @ManyToOne(optional = false)
     private AppUser appUser;
 
     private int playtimeForever;
@@ -42,4 +28,7 @@ public class GamePlaytimeRecord {
     private int playtimeMacForever;
     private int playtimeWindowsForever;
     private int playtimeDeckForever;
+
+    @Enumerated(EnumType.STRING)
+    private Constants.PlaytimeRecordType playtimeType;
 }

--- a/src/main/java/com/stucko09/steam_aggregator/model/GamePlaytimeRecord.java
+++ b/src/main/java/com/stucko09/steam_aggregator/model/GamePlaytimeRecord.java
@@ -1,10 +1,6 @@
 package com.stucko09.steam_aggregator.model;
 
-import com.stucko09.steam_aggregator.util.Constants;
-
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,6 +25,6 @@ public class GamePlaytimeRecord extends BaseRecordClass {
     private int playtimeWindowsForever;
     private int playtimeDeckForever;
 
-    @Enumerated(EnumType.STRING)
-    private Constants.PlaytimeRecordType playtimeType;
+    private boolean isFirstGameEntry = false;
+    private boolean isFirstUserEntry = false;
 }

--- a/src/main/java/com/stucko09/steam_aggregator/model/GameRecord.java
+++ b/src/main/java/com/stucko09/steam_aggregator/model/GameRecord.java
@@ -5,18 +5,19 @@ import java.time.ZonedDateTime;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import com.github.dozermapper.core.Mapping;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
 @Data
 @Entity
-public class GamePlaytimeRecord {
+public class GameRecord {
     @Setter(AccessLevel.NONE)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,13 +31,8 @@ public class GamePlaytimeRecord {
     @UpdateTimestamp
     private ZonedDateTime updateTimestamp;
 
-    @OneToOne
-    private GameRecord gameRecord;
+    @Mapping("appid")
+    private Long steamAppId;
 
-    private int playtimeForever;
-    private int playtime2Weeks;
-    private int playtimeLinuxForever;
-    private int playtimeMacForever;
-    private int playtimeWindowsForever;
-    private int playtimeDeckForever;
+    private String name;
 }

--- a/src/main/java/com/stucko09/steam_aggregator/model/GameRecord.java
+++ b/src/main/java/com/stucko09/steam_aggregator/model/GameRecord.java
@@ -1,38 +1,22 @@
 package com.stucko09.steam_aggregator.model;
 
-import java.time.ZonedDateTime;
-
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
 import com.github.dozermapper.core.Mapping;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Data
 @Entity
-public class GameRecord {
-    @Setter(AccessLevel.NONE)
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Setter(AccessLevel.NONE)
-    @CreationTimestamp
-    private ZonedDateTime creationTimestamp;
-
-    @Setter(AccessLevel.NONE)
-    @UpdateTimestamp
-    private ZonedDateTime updateTimestamp;
+@Getter
+@Setter
+@NoArgsConstructor
+public class GameRecord extends BaseRecordClass {
 
     @Mapping("appid")
     private Long steamAppId;
 
+    @Column(nullable = false)
     private String name;
 }

--- a/src/main/java/com/stucko09/steam_aggregator/model/steam/SteamGame.java
+++ b/src/main/java/com/stucko09/steam_aggregator/model/steam/SteamGame.java
@@ -1,0 +1,15 @@
+package com.stucko09.steam_aggregator.model.steam;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Setter
+@Getter
+public class SteamGame {
+    private String appId;
+    private String name;
+    private String playtime2Weeks;
+    private String playtimeForever;
+}

--- a/src/main/java/com/stucko09/steam_aggregator/model/steam/SteamGame.java
+++ b/src/main/java/com/stucko09/steam_aggregator/model/steam/SteamGame.java
@@ -1,15 +1,23 @@
 package com.stucko09.steam_aggregator.model.steam;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-@AllArgsConstructor
-@Setter
-@Getter
+import lombok.Data;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Data
 public class SteamGame {
-    private String appId;
+    private Long appid;
     private String name;
-    private String playtime2Weeks;
-    private String playtimeForever;
+    private int playtimeForever;
+
+    @JsonProperty("playtime_2weeks")
+    private int playtime2Weeks;
+
+    private int playtimeWindowsForever;
+    private int playtimeMacForever;
+    private int playtimeLinuxForever;
+    private int playtimeDeckForever;
 }

--- a/src/main/java/com/stucko09/steam_aggregator/model/steam/SteamGetOwnedGamesResponse.java
+++ b/src/main/java/com/stucko09/steam_aggregator/model/steam/SteamGetOwnedGamesResponse.java
@@ -1,0 +1,9 @@
+package com.stucko09.steam_aggregator.model.steam;
+
+import lombok.Data;
+
+@Data
+public class SteamGetOwnedGamesResponse {
+    private String gameCount;
+    private SteamGame[] games;
+}

--- a/src/main/java/com/stucko09/steam_aggregator/model/steam/SteamGetOwnedGamesResponse.java
+++ b/src/main/java/com/stucko09/steam_aggregator/model/steam/SteamGetOwnedGamesResponse.java
@@ -1,9 +1,15 @@
 package com.stucko09.steam_aggregator.model.steam;
 
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import lombok.Data;
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Data
 public class SteamGetOwnedGamesResponse {
     private String gameCount;
-    private SteamGame[] games;
+    private List<SteamGame> games;
 }

--- a/src/main/java/com/stucko09/steam_aggregator/model/steam/SteamGetRecentGamesResponse.java
+++ b/src/main/java/com/stucko09/steam_aggregator/model/steam/SteamGetRecentGamesResponse.java
@@ -1,0 +1,15 @@
+package com.stucko09.steam_aggregator.model.steam;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Data;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Data
+public class SteamGetRecentGamesResponse {
+    private String totalCount;
+    private List<SteamGame> games;
+}

--- a/src/main/java/com/stucko09/steam_aggregator/model/steam/SteamResponse.java
+++ b/src/main/java/com/stucko09/steam_aggregator/model/steam/SteamResponse.java
@@ -1,0 +1,8 @@
+package com.stucko09.steam_aggregator.model.steam;
+
+import lombok.Data;
+
+@Data
+public class SteamResponse<T> {
+    private T response;
+}

--- a/src/main/java/com/stucko09/steam_aggregator/repository/GamePlaytimeRecordRepository.java
+++ b/src/main/java/com/stucko09/steam_aggregator/repository/GamePlaytimeRecordRepository.java
@@ -2,8 +2,11 @@ package com.stucko09.steam_aggregator.repository;
 
 import org.springframework.data.repository.CrudRepository;
 
+import com.stucko09.steam_aggregator.model.AppUser;
 import com.stucko09.steam_aggregator.model.GamePlaytimeRecord;
+import com.stucko09.steam_aggregator.model.GameRecord;
 
 public interface GamePlaytimeRecordRepository extends CrudRepository<GamePlaytimeRecord, Long> {
-    
+    public boolean existsByAppUser(AppUser appUser);
+    public boolean existsByGameRecord(GameRecord gameRecord);
 }

--- a/src/main/java/com/stucko09/steam_aggregator/repository/GamePlaytimeRecordRepository.java
+++ b/src/main/java/com/stucko09/steam_aggregator/repository/GamePlaytimeRecordRepository.java
@@ -1,0 +1,9 @@
+package com.stucko09.steam_aggregator.repository;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.stucko09.steam_aggregator.model.GamePlaytimeRecord;
+
+public interface GamePlaytimeRecordRepository extends CrudRepository<GamePlaytimeRecord, Long> {
+    
+}

--- a/src/main/java/com/stucko09/steam_aggregator/repository/GamePlaytimeRecordRepository.java
+++ b/src/main/java/com/stucko09/steam_aggregator/repository/GamePlaytimeRecordRepository.java
@@ -8,5 +8,5 @@ import com.stucko09.steam_aggregator.model.GameRecord;
 
 public interface GamePlaytimeRecordRepository extends CrudRepository<GamePlaytimeRecord, Long> {
     public boolean existsByAppUser(AppUser appUser);
-    public boolean existsByGameRecord(GameRecord gameRecord);
+    public boolean existsByGameRecordAndAppUser(GameRecord gameRecord, AppUser appUser);
 }

--- a/src/main/java/com/stucko09/steam_aggregator/repository/GameRecordRepository.java
+++ b/src/main/java/com/stucko09/steam_aggregator/repository/GameRecordRepository.java
@@ -1,0 +1,9 @@
+package com.stucko09.steam_aggregator.repository;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.stucko09.steam_aggregator.model.GameRecord;
+
+public interface GameRecordRepository extends CrudRepository<GameRecord, Long> {
+    public boolean existsBySteamAppId(Long steamAppId);
+}

--- a/src/main/java/com/stucko09/steam_aggregator/repository/GameRecordRepository.java
+++ b/src/main/java/com/stucko09/steam_aggregator/repository/GameRecordRepository.java
@@ -1,9 +1,12 @@
 package com.stucko09.steam_aggregator.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.CrudRepository;
 
 import com.stucko09.steam_aggregator.model.GameRecord;
 
 public interface GameRecordRepository extends CrudRepository<GameRecord, Long> {
     public boolean existsBySteamAppId(Long steamAppId);
+    public Optional<GameRecord> findBySteamAppId(Long steamAppId);
 }

--- a/src/main/java/com/stucko09/steam_aggregator/repository/UserRepository.java
+++ b/src/main/java/com/stucko09/steam_aggregator/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.stucko09.steam_aggregator.repository;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.stucko09.steam_aggregator.model.AppUser;
+
+public interface UserRepository extends CrudRepository<AppUser, Long> {
+    public AppUser findBySteamUserId(Long steamUserId);
+
+    public boolean existsBySteamUserId(Long steamUserId);
+}

--- a/src/main/java/com/stucko09/steam_aggregator/service/GameService.java
+++ b/src/main/java/com/stucko09/steam_aggregator/service/GameService.java
@@ -54,7 +54,7 @@ public class GameService {
         if(isFirstUserEntry) {
             gamePlaytimeRecord.setFirstUserEntry(true);
             gamePlaytimeRecord.setFirstGameEntry(true);
-        } else if (!gamePlaytimeRecordRepository.existsByGameRecord(gameRecord)) {
+        } else if (!gamePlaytimeRecordRepository.existsByGameRecordAndAppUser(gameRecord, user)) {
             gamePlaytimeRecord.setFirstGameEntry(true);
         }
 

--- a/src/main/java/com/stucko09/steam_aggregator/service/GameService.java
+++ b/src/main/java/com/stucko09/steam_aggregator/service/GameService.java
@@ -1,0 +1,63 @@
+package com.stucko09.steam_aggregator.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.github.dozermapper.core.Mapper;
+import com.stucko09.steam_aggregator.model.AppUser;
+import com.stucko09.steam_aggregator.model.GamePlaytimeRecord;
+import com.stucko09.steam_aggregator.model.GameRecord;
+import com.stucko09.steam_aggregator.model.steam.SteamGame;
+import com.stucko09.steam_aggregator.repository.GamePlaytimeRecordRepository;
+import com.stucko09.steam_aggregator.repository.GameRecordRepository;
+
+@Service
+public class GameService {
+    @Autowired
+    private GameRecordRepository gameRecordRepository;
+
+    @Autowired
+    private GamePlaytimeRecordRepository gamePlaytimeRecordRepository;
+
+    @Autowired
+    private Mapper dozerBeanMapper;
+
+    public GameRecord saveOrRetrieveGameRecord(SteamGame steamGame) {
+        return gameRecordRepository.findBySteamAppId(steamGame.getAppid()).orElseGet(() -> {
+            GameRecord newGameRecord = dozerBeanMapper.map(steamGame, GameRecord.class);
+            return gameRecordRepository.save(newGameRecord);
+        });
+    }
+
+    public GameRecord saveNewGameRecord(SteamGame steamGame) {
+        GameRecord newGameRecord = dozerBeanMapper.map(steamGame, GameRecord.class);
+        return gameRecordRepository.save(newGameRecord);
+    }
+
+    public GamePlaytimeRecord saveDailyPlaytimeRecord(SteamGame steamGame, AppUser user) {
+        return saveNewPlaytimeRecord(steamGame, user, false);
+    }
+
+    public GamePlaytimeRecord saveInitialPlaytimeRecord(SteamGame steamGame, AppUser user) {
+        return saveNewPlaytimeRecord(steamGame, user, true);
+    }
+
+    private GamePlaytimeRecord saveNewPlaytimeRecord(SteamGame steamGame, AppUser user, boolean isFirstUserEntry) {
+        GameRecord gameRecord = saveOrRetrieveGameRecord(steamGame);
+
+        GamePlaytimeRecord gamePlaytimeRecord = dozerBeanMapper.map(steamGame, GamePlaytimeRecord.class);
+        gamePlaytimeRecord.setGameRecord(gameRecord);
+        gamePlaytimeRecord.setAppUser(user);
+
+        // first entry flags default to false; only set them if it's the first user entry or game entry
+        // if it's first user entry, it's also logically the first game entry for that user
+        if(isFirstUserEntry) {
+            gamePlaytimeRecord.setFirstUserEntry(true);
+            gamePlaytimeRecord.setFirstGameEntry(true);
+        } else if (!gamePlaytimeRecordRepository.existsByGameRecord(gameRecord)) {
+            gamePlaytimeRecord.setFirstGameEntry(true);
+        }
+
+        return gamePlaytimeRecordRepository.save(gamePlaytimeRecord);
+    }
+}

--- a/src/main/java/com/stucko09/steam_aggregator/service/StatsCollectionService.java
+++ b/src/main/java/com/stucko09/steam_aggregator/service/StatsCollectionService.java
@@ -4,11 +4,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.github.dozermapper.core.Mapper;
+import com.stucko09.steam_aggregator.model.AppUser;
 import com.stucko09.steam_aggregator.model.GamePlaytimeRecord;
 import com.stucko09.steam_aggregator.model.GameRecord;
 import com.stucko09.steam_aggregator.model.steam.SteamGame;
 import com.stucko09.steam_aggregator.model.steam.SteamGetOwnedGamesResponse;
-import com.stucko09.steam_aggregator.model.steam.SteamResponse;
 import com.stucko09.steam_aggregator.repository.GamePlaytimeRecordRepository;
 import com.stucko09.steam_aggregator.repository.GameRecordRepository;
 
@@ -27,19 +27,20 @@ public class StatsCollectionService {
     @Autowired
     private GamePlaytimeRecordRepository gamePlaytimeRecordRepository;
 
-    public void collectAndSaveDailyPlaytimeStats(Long steamId) {
+    public void collectAndSaveDailyPlaytimeStats(Long steamId, AppUser user) {
         SteamGetOwnedGamesResponse ownedGamesResponse = steamApiService.getOwnedGames(steamId).getResponse();
 
         for (SteamGame steamGame : ownedGamesResponse.getGames()) {
             if (steamGame.getPlaytimeForever() == 0) continue;
 
-            GameRecord gameRecord = dozerBeanMapper.map(steamGame, GameRecord.class);
-            if (!gameRecordRepository.existsBySteamAppId(steamGame.getAppid())) {
-                gameRecordRepository.save(gameRecord);
-            }
+            GameRecord gameRecord = gameRecordRepository.findBySteamAppId(steamGame.getAppid()).orElseGet(() -> {
+                GameRecord newGameRecord = dozerBeanMapper.map(steamGame, GameRecord.class);
+                return gameRecordRepository.save(newGameRecord);
+            });
 
             GamePlaytimeRecord gamePlaytimeRecord = dozerBeanMapper.map(steamGame, GamePlaytimeRecord.class);
             gamePlaytimeRecord.setGameRecord(gameRecord);
+            gamePlaytimeRecord.setAppUser(user);
 
             gamePlaytimeRecordRepository.save(gamePlaytimeRecord);
         }

--- a/src/main/java/com/stucko09/steam_aggregator/service/StatsCollectionService.java
+++ b/src/main/java/com/stucko09/steam_aggregator/service/StatsCollectionService.java
@@ -1,0 +1,47 @@
+package com.stucko09.steam_aggregator.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.github.dozermapper.core.Mapper;
+import com.stucko09.steam_aggregator.model.GamePlaytimeRecord;
+import com.stucko09.steam_aggregator.model.GameRecord;
+import com.stucko09.steam_aggregator.model.steam.SteamGame;
+import com.stucko09.steam_aggregator.model.steam.SteamGetOwnedGamesResponse;
+import com.stucko09.steam_aggregator.model.steam.SteamResponse;
+import com.stucko09.steam_aggregator.repository.GamePlaytimeRecordRepository;
+import com.stucko09.steam_aggregator.repository.GameRecordRepository;
+
+@Service
+public class StatsCollectionService {
+
+    @Autowired
+    private SteamApiService steamApiService;
+
+    @Autowired
+    private Mapper dozerBeanMapper;
+
+    @Autowired
+    private GameRecordRepository gameRecordRepository;
+
+    @Autowired
+    private GamePlaytimeRecordRepository gamePlaytimeRecordRepository;
+
+    public void collectAndSaveDailyPlaytimeStats(Long steamId) {
+        SteamGetOwnedGamesResponse ownedGamesResponse = steamApiService.getOwnedGames(steamId).getResponse();
+
+        for (SteamGame steamGame : ownedGamesResponse.getGames()) {
+            if (steamGame.getPlaytimeForever() == 0) continue;
+
+            GameRecord gameRecord = dozerBeanMapper.map(steamGame, GameRecord.class);
+            if (!gameRecordRepository.existsBySteamAppId(steamGame.getAppid())) {
+                gameRecordRepository.save(gameRecord);
+            }
+
+            GamePlaytimeRecord gamePlaytimeRecord = dozerBeanMapper.map(steamGame, GamePlaytimeRecord.class);
+            gamePlaytimeRecord.setGameRecord(gameRecord);
+
+            gamePlaytimeRecordRepository.save(gamePlaytimeRecord);
+        }
+    }
+}

--- a/src/main/java/com/stucko09/steam_aggregator/service/SteamApiService.java
+++ b/src/main/java/com/stucko09/steam_aggregator/service/SteamApiService.java
@@ -25,7 +25,7 @@ public class SteamApiService {
     @Autowired
     private RestTemplate restTemplate;
 
-    public SteamResponse<SteamGetOwnedGamesResponse> getOwnedGames(Long steamId) {
+    public SteamResponse<SteamGetOwnedGamesResponse> getOwnedGames(Long steamId) {        
         RequestEntity<Void> requestEntity = RequestEntity
                 .get(steamProperties.getHostname()
                         + String.format(GET_OWNED_GAMES_REQUEST_PATH, steamProperties.getApiKey(), steamId))

--- a/src/main/java/com/stucko09/steam_aggregator/service/SteamApiService.java
+++ b/src/main/java/com/stucko09/steam_aggregator/service/SteamApiService.java
@@ -10,6 +10,7 @@ import org.springframework.web.client.RestTemplate;
 
 import com.stucko09.steam_aggregator.config.SteamProperties;
 import com.stucko09.steam_aggregator.model.steam.SteamGetOwnedGamesResponse;
+import com.stucko09.steam_aggregator.model.steam.SteamGetRecentGamesResponse;
 import com.stucko09.steam_aggregator.model.steam.SteamResponse;
 
 import lombok.extern.apachecommons.CommonsLog;
@@ -18,6 +19,7 @@ import lombok.extern.apachecommons.CommonsLog;
 @Service
 public class SteamApiService {
     private static final String GET_OWNED_GAMES_REQUEST_PATH = "/IPlayerService/GetOwnedGames/v0001/?key=%s&steamid=%s&format=json&include_appinfo=1";
+    private static final String GET_RECENT_GAMES_REQUEST_PATH = "/IPlayerService/GetRecentlyPlayedGames/v0001/?key=%s&steamid=%s&format=json&include_appinfo=1";
 
     @Autowired
     private SteamProperties steamProperties;
@@ -25,15 +27,20 @@ public class SteamApiService {
     @Autowired
     private RestTemplate restTemplate;
 
-    public SteamResponse<SteamGetOwnedGamesResponse> getOwnedGames(Long steamId) {        
+    public SteamResponse<SteamGetOwnedGamesResponse> getOwnedGames(Long steamId, String apiKey) {
+        return makeRequestToSteam(steamId, apiKey, GET_OWNED_GAMES_REQUEST_PATH, new ParameterizedTypeReference<SteamResponse<SteamGetOwnedGamesResponse>>() {});
+    }
+
+    public SteamResponse<SteamGetRecentGamesResponse> getRecentlyPlayedGames(Long steamId, String apiKey) {
+        return makeRequestToSteam(steamId, apiKey, GET_RECENT_GAMES_REQUEST_PATH, new ParameterizedTypeReference<SteamResponse<SteamGetRecentGamesResponse>>() {});
+    }
+
+    private <T> SteamResponse<T> makeRequestToSteam(Long steamId, String apiKey, String requestPath, ParameterizedTypeReference<SteamResponse<T>> responseType) {
         RequestEntity<Void> requestEntity = RequestEntity
                 .get(steamProperties.getHostname()
-                        + String.format(GET_OWNED_GAMES_REQUEST_PATH, steamProperties.getApiKey(), steamId))
+                        + String.format(requestPath, apiKey, steamId))
                 .accept(MediaType.APPLICATION_JSON).build();
-        ResponseEntity<SteamResponse<SteamGetOwnedGamesResponse>> response = restTemplate.exchange(
-                requestEntity,
-                new ParameterizedTypeReference<SteamResponse<SteamGetOwnedGamesResponse>>() {
-                });
+        ResponseEntity<SteamResponse<T>> response = restTemplate.exchange(requestEntity, responseType);
 
         return response.getBody();
     }

--- a/src/main/java/com/stucko09/steam_aggregator/service/SteamApiService.java
+++ b/src/main/java/com/stucko09/steam_aggregator/service/SteamApiService.java
@@ -1,7 +1,6 @@
 package com.stucko09.steam_aggregator.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
@@ -9,7 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stucko09.steam_aggregator.config.SteamProperties;
 import com.stucko09.steam_aggregator.model.steam.SteamGetOwnedGamesResponse;
 import com.stucko09.steam_aggregator.model.steam.SteamResponse;
 
@@ -20,18 +19,16 @@ import lombok.extern.apachecommons.CommonsLog;
 public class SteamApiService {
     private static final String GET_OWNED_GAMES_REQUEST_PATH = "/IPlayerService/GetOwnedGames/v0001/?key=%s&steamid=%s&format=json&include_appinfo=1";
 
-    @Value("${steam.hostname}")
-    private String steamApiHostname;
-
-    @Value("${steam.api-key}")
-    private String apiKey;
+    @Autowired
+    private SteamProperties steamProperties;
 
     @Autowired
     private RestTemplate restTemplate;
 
     public SteamResponse<SteamGetOwnedGamesResponse> getOwnedGames(Long steamId) {
         RequestEntity<Void> requestEntity = RequestEntity
-                .get(steamApiHostname + String.format(GET_OWNED_GAMES_REQUEST_PATH, apiKey, steamId))
+                .get(steamProperties.getHostname()
+                        + String.format(GET_OWNED_GAMES_REQUEST_PATH, steamProperties.getApiKey(), steamId))
                 .accept(MediaType.APPLICATION_JSON).build();
         ResponseEntity<SteamResponse<SteamGetOwnedGamesResponse>> response = restTemplate.exchange(
                 requestEntity,

--- a/src/main/java/com/stucko09/steam_aggregator/service/SteamApiService.java
+++ b/src/main/java/com/stucko09/steam_aggregator/service/SteamApiService.java
@@ -1,0 +1,36 @@
+package com.stucko09.steam_aggregator.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.stucko09.steam_aggregator.model.steam.SteamGetOwnedGamesResponse;
+import com.stucko09.steam_aggregator.model.steam.SteamResponse;
+
+@Service
+public class SteamApiService {
+    private static final String GET_OWNED_GAMES_REQUEST_PATH = "/IPlayerService/GetOwnedGames/v0001/?key=%s&steamid=%s&format=json";
+
+    @Value("${steam.hostname}")
+    private String steamApiHostname;
+
+    @Value("${steam.api-key}")
+    private String apiKey;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    public SteamResponse<SteamGetOwnedGamesResponse> getOwnedGames(String steamId) {
+        ResponseEntity<SteamResponse<SteamGetOwnedGamesResponse>> response = restTemplate.exchange(
+                steamApiHostname + String.format(GET_OWNED_GAMES_REQUEST_PATH, apiKey, steamId),
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<SteamResponse<SteamGetOwnedGamesResponse>>() {
+                });
+        return response.getBody();
+    }
+}

--- a/src/main/java/com/stucko09/steam_aggregator/service/SteamApiService.java
+++ b/src/main/java/com/stucko09/steam_aggregator/service/SteamApiService.java
@@ -3,17 +3,22 @@ package com.stucko09.steam_aggregator.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stucko09.steam_aggregator.model.steam.SteamGetOwnedGamesResponse;
 import com.stucko09.steam_aggregator.model.steam.SteamResponse;
 
+import lombok.extern.apachecommons.CommonsLog;
+
+@CommonsLog
 @Service
 public class SteamApiService {
-    private static final String GET_OWNED_GAMES_REQUEST_PATH = "/IPlayerService/GetOwnedGames/v0001/?key=%s&steamid=%s&format=json";
+    private static final String GET_OWNED_GAMES_REQUEST_PATH = "/IPlayerService/GetOwnedGames/v0001/?key=%s&steamid=%s&format=json&include_appinfo=1";
 
     @Value("${steam.hostname}")
     private String steamApiHostname;
@@ -24,13 +29,15 @@ public class SteamApiService {
     @Autowired
     private RestTemplate restTemplate;
 
-    public SteamResponse<SteamGetOwnedGamesResponse> getOwnedGames(String steamId) {
+    public SteamResponse<SteamGetOwnedGamesResponse> getOwnedGames(Long steamId) {
+        RequestEntity<Void> requestEntity = RequestEntity
+                .get(steamApiHostname + String.format(GET_OWNED_GAMES_REQUEST_PATH, apiKey, steamId))
+                .accept(MediaType.APPLICATION_JSON).build();
         ResponseEntity<SteamResponse<SteamGetOwnedGamesResponse>> response = restTemplate.exchange(
-                steamApiHostname + String.format(GET_OWNED_GAMES_REQUEST_PATH, apiKey, steamId),
-                HttpMethod.GET,
-                null,
+                requestEntity,
                 new ParameterizedTypeReference<SteamResponse<SteamGetOwnedGamesResponse>>() {
                 });
+
         return response.getBody();
     }
 }

--- a/src/main/java/com/stucko09/steam_aggregator/service/UserService.java
+++ b/src/main/java/com/stucko09/steam_aggregator/service/UserService.java
@@ -11,8 +11,14 @@ public class UserService {
     @Autowired
     private UserRepository userRepository;
 
-    public AppUser registerUser(Long steamId) {
-        return userRepository.save(new AppUser(steamId));
+    @Autowired
+    private StatsCollectionService statsCollectionService;
+
+    public AppUser registerUserAndSaveInitialPlaytime(Long steamId, String apiKey) {
+        AppUser user = registerUser(steamId);
+        user.setApiKey(apiKey);
+        statsCollectionService.collectAndSaveInitialPlaytimeStats(user);
+        return user;
     }
 
     public AppUser retrieveUserOrThrowException(Long steamId) {
@@ -24,5 +30,9 @@ public class UserService {
 
     public boolean userIsRegistered(Long steamId) {
         return userRepository.existsBySteamUserId(steamId);
+    }
+
+    private AppUser registerUser(Long steamId) {
+        return userRepository.save(new AppUser(steamId));
     }
 }

--- a/src/main/java/com/stucko09/steam_aggregator/service/UserService.java
+++ b/src/main/java/com/stucko09/steam_aggregator/service/UserService.java
@@ -1,0 +1,28 @@
+package com.stucko09.steam_aggregator.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.stucko09.steam_aggregator.model.AppUser;
+import com.stucko09.steam_aggregator.repository.UserRepository;
+
+@Service
+public class UserService {
+    @Autowired
+    private UserRepository userRepository;
+
+    public AppUser registerUser(Long steamId) {
+        return userRepository.save(new AppUser(steamId));
+    }
+
+    public AppUser retrieveUserOrThrowException(Long steamId) {
+        AppUser user = userRepository.findBySteamUserId(steamId);
+        if (user == null)
+            throw new RuntimeException("User with steamId " + steamId + " is not registered.");
+        return user;
+    }
+
+    public boolean userIsRegistered(Long steamId) {
+        return userRepository.existsBySteamUserId(steamId);
+    }
+}

--- a/src/main/java/com/stucko09/steam_aggregator/util/Constants.java
+++ b/src/main/java/com/stucko09/steam_aggregator/util/Constants.java
@@ -1,0 +1,8 @@
+package com.stucko09.steam_aggregator.util;
+
+public class Constants {
+
+    public enum PlaytimeRecordType {
+        INITIAL, DAILY
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+    application:
+        name: steam-playtime-aggregator
+    datasource:
+        url: jdbc:h2:mem:localdb
+
+steam:
+    hostname: http://api.steampowered.com

--- a/src/test/java/com/stucko09/steam_aggregator/SteamPlaytimeAggregatorApplicationTests.java
+++ b/src/test/java/com/stucko09/steam_aggregator/SteamPlaytimeAggregatorApplicationTests.java
@@ -1,0 +1,15 @@
+package com.stucko09.steam_aggregator;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("junit")
+@SpringBootTest
+class SteamPlaytimeAggregatorApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/src/test/resources/application-junit.yml
+++ b/src/test/resources/application-junit.yml
@@ -1,0 +1,7 @@
+spring:
+    application:
+        name: steam-playtime-aggregator
+
+steam:
+    hostname: http://fakeurl.com
+    apiKey: 123456789abcdefg


### PR DESCRIPTION
Added two main API requests: registerUser and saveDailyPlaytime.
RegisterUser will save a new user to the DB and save their current playtime snapshot to the DB.
SaveDailyPlaytime will pull a new snapshot of their playtime from Steam.